### PR TITLE
github-labeller 1.3.0

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -18,7 +18,7 @@ specified account.
 - **EventEmitter** An event emitter you can use for listening for specific events:
  - `added` (owner, repo, label, err, data)–after a label was created
 
-### `addToRepo(ev, gh, owner, repo, label, callback)`
+### `addToRepo(ev, gh, owner, repo, label, labels, callback)`
 Creates a new label.
 
 #### Params
@@ -27,8 +27,8 @@ Creates a new label.
 - **String** `owner`: The owner username.
 - **String** `repo`: The repository name.
 - **Object** `label`: The label object.
+- **Array** `labels`: Labels to patch instead of post.
 - **Function** `callback`: Callback function
 
 #### Return
 - **Request** The request object.
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -84,13 +84,13 @@ function GitHubLabeller (labels, options, callback) {
     }
 
     if (repo) {
-        GitHubLabeller.addToRepo(ev, gh, user, repo, labels, callback);
+        GitHubLabeller.checkRepo(ev, gh, user, repo, labels, callback);
     } else {
         gh.get("users/" + user + "/repos", { all: true }, function (err, repos) {
             if (err) { return callback(err); }
             SameTime(repos.map(function (c) {
                 return function (done) {
-                    GitHubLabeller.addToRepo(ev, gh, user, c.name, labels, done);
+                    GitHubLabeller.checkRepo(ev, gh, user, c.name, labels, done);
                 }
             }), callback);
         });
@@ -98,6 +98,34 @@ function GitHubLabeller (labels, options, callback) {
 
     return ev;
 }
+
+/**
+ * checkRepo
+ * Check the current labels, then post or patch new ones.
+ *
+ * @name checkRepo
+ * @function
+ * @param {EventEmitter} ev The event emitter instance.
+ * @param {GitHub} gh The `gh.js` instance.
+ * @param {String} owner The owner username.
+ * @param {String} repo The repository name.
+ * @param {Object} label The label object.
+ * @param {Function} callback Callback function
+ * @return {Request} The request object.
+ */
+GitHubLabeller.checkRepo = function (ev, gh, owner, repo, label, callback) {
+    return gh.get("repos/" + owner + "/" + repo + "/labels", function (err, labels) {
+      var i = 0;
+
+      if (err) { return callback(err); }
+
+      for (; i < labels.length; ++i) {
+          labels[i] = labels[i].name;
+      }
+
+      GitHubLabeller.addToRepo(ev, gh, owner, repo, label, labels, callback);
+    });
+};
 
 /**
  * addToRepo
@@ -110,21 +138,29 @@ function GitHubLabeller (labels, options, callback) {
  * @param {String} owner The owner username.
  * @param {String} repo The repository name.
  * @param {Object} label The label object.
+ * @param {Array} label The list of current labels.
  * @param {Function} callback Callback function
  * @return {Request} The request object.
  */
-GitHubLabeller.addToRepo = function (ev, gh, owner, repo, label, callback) {
+GitHubLabeller.addToRepo = function (ev, gh, owner, repo, label, labels, callback) {
+    var endpoint = "repos/" + owner + "/" + repo + "/labels";
+
     if (Array.isArray(label)) {
         return SameTime(label.map(function (c) {
             return function (done) {
-                GitHubLabeller.addToRepo(ev, gh, owner, repo, c, function (err, data) {
+                GitHubLabeller.addToRepo(ev, gh, owner, repo, c, labels, function (err, data) {
                     ev.emit("added", owner, repo, c, err, data);
                     done(null, data);
                 });
             };
         }), callback);
     }
-    return gh.get("repos/" + owner + "/" + repo + "/labels", { data: label }, callback);
+
+    if (labels.indexOf(label.name) > -1) {
+      endpoint += "/" + encodeURIComponent(label.name);
+    }
+
+    return gh.get(endpoint, { data: label }, callback);
 };
 
 module.exports = GitHubLabeller;

--- a/lib/index.js
+++ b/lib/index.js
@@ -84,13 +84,13 @@ function GitHubLabeller (labels, options, callback) {
     }
 
     if (repo) {
-        GitHubLabeller.addToRepo(ev, gh, user, repo, labels, callback);
+        GitHubLabeller.checkRepo(ev, gh, user, repo, labels, callback);
     } else {
         gh.get("users/" + user + "/repos", { all: true }, function (err, repos) {
             if (err) { return callback(err); }
             SameTime(repos.map(function (c) {
                 return function (done) {
-                    GitHubLabeller.addToRepo(ev, gh, user, c.name, labels, done);
+                    GitHubLabeller.checkRepo(ev, gh, user, c.name, labels, done);
                 }
             }), callback);
         });
@@ -98,6 +98,34 @@ function GitHubLabeller (labels, options, callback) {
 
     return ev;
 }
+
+/**
+ * checkRepo
+ * Check the current labels, then post or patch new ones.
+ *
+ * @name checkRepo
+ * @function
+ * @param {EventEmitter} ev The event emitter instance.
+ * @param {GitHub} gh The `gh.js` instance.
+ * @param {String} owner The owner username.
+ * @param {String} repo The repository name.
+ * @param {Object} label The label object.
+ * @param {Function} callback Callback function
+ * @return {Request} The request object.
+ */
+GitHubLabeller.checkRepo = function (ev, gh, owner, repo, label, callback) {
+    return gh.get("repos/" + owner + "/" + repo + "/labels", function (err, labels) {
+      var i = 0;
+
+      if (err) { return callback(err); }
+
+      for (; i < labels.length; ++i) {
+          labels[i] = labels[i].name;
+      }
+
+      GitHubLabeller.addToRepo(ev, gh, owner, repo, label, labels, callback);
+    });
+};
 
 /**
  * addToRepo
@@ -110,21 +138,29 @@ function GitHubLabeller (labels, options, callback) {
  * @param {String} owner The owner username.
  * @param {String} repo The repository name.
  * @param {Object} label The label object.
+ * @param {Array} label The list of current labels.
  * @param {Function} callback Callback function
  * @return {Request} The request object.
  */
-GitHubLabeller.addToRepo = function (ev, gh, owner, repo, label, callback) {
+GitHubLabeller.addToRepo = function (ev, gh, owner, repo, label, labels, callback) {
+    var endpoint = "repos/" + owner + "/" + repo + "/labels";
+
     if (Array.isArray(label)) {
         return SameTime(label.map(function (c) {
             return function (done) {
-                GitHubLabeller.addToRepo(ev, gh, owner, repo, c, function (err, data) {
+                GitHubLabeller.addToRepo(ev, gh, owner, repo, c, labels, function (err, data) {
                     ev.emit("added", owner, repo, c, err, data);
                     done(null, data);
                 });
             };
         }), callback);
     }
-    return gh.get("repos/" + owner + "/" + repo + "/labels", { data: label }, callback);
+
+    if (labels.indexOf(label.name) > -1) {
+      endpoint += "/" + label.name;
+    }
+
+    return gh.get(endpoint, { data: label }, callback);
 };
 
 module.exports = GitHubLabeller;

--- a/lib/index.js
+++ b/lib/index.js
@@ -157,7 +157,7 @@ GitHubLabeller.addToRepo = function (ev, gh, owner, repo, label, labels, callbac
     }
 
     if (labels.indexOf(label.name) > -1) {
-      endpoint += "/" + label.name;
+        endpoint += "/" + label.name;
     }
 
     return gh.get(endpoint, { data: label }, callback);

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
     "automatization"
   ],
   "author": "Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)",
+  "contributors": [
+    "Ionică Bizău <bizauionica@gmail.com> (http://ionicabizau.net)",
+    "Titus Wormer <tituswormer@gmail.com> (http://wooorm.com)"
+  ],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/IonicaBizau/github-labeller/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-labeller",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Automagically create issue labels in your GitHub projects.",
   "main": "lib/index.js",
   "bin": {


### PR DESCRIPTION
Thanks to @woorm, now we can update existing labels by overwrite them. That means we can now set new colors for the default labels (without deleting them all).

For more details on this change, see #6. :sparkles: 
